### PR TITLE
fix stripe api headers

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -511,7 +511,7 @@ module ActiveMerchant #:nodoc:
         idempotency_key = options[:idempotency_key]
 
         headers = {
-          "Authorization" => "Basic " + Base64.encode64(key.to_s + ":").strip,
+          "Authorization" => "Basic " + Base64.strict_encode64(key.to_s + ":").strip,
           "User-Agent" => "Stripe/v1 ActiveMerchantBindings/#{ActiveMerchant::VERSION}",
           "Stripe-Version" => api_version(options),
           "X-Stripe-Client-User-Agent" => stripe_client_user_agent(options),

--- a/test/unit/gateways/barclays_epdq_extra_plus_test.rb
+++ b/test/unit/gateways/barclays_epdq_extra_plus_test.rb
@@ -93,21 +93,21 @@ class BarclaysEpdqExtraPlusTest < Test::Unit::TestCase
   def test_successful_authorize
     @gateway.expects(:add_pair).at_least(1)
     @gateway.expects(:add_pair).with(anything, 'ECI', '7')
-    @gateway.expects(:add_pair).with(anything, 'Operation', 'PAU')
+    @gateway.expects(:add_pair).with(anything, 'Operation', 'RES')
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
     assert response = @gateway.authorize(@amount, @credit_card, @options)
     assert_success response
-    assert_equal '3014726;PAU', response.authorization
+    assert_equal '3014726;RES', response.authorization
     assert response.test?
   end
 
   def test_successful_authorize_with_mastercard
     @gateway.expects(:add_pair).at_least(1)
-    @gateway.expects(:add_pair).with(anything, 'Operation', 'PAU')
+    @gateway.expects(:add_pair).with(anything, 'Operation', 'RES')
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
     assert response = @gateway.authorize(@amount, @mastercard, @options)
     assert_success response
-    assert_equal '3014726;PAU', response.authorization
+    assert_equal '3014726;RES', response.authorization
     assert response.test?
   end
 
@@ -117,7 +117,7 @@ class BarclaysEpdqExtraPlusTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_purchase_response)
     assert response = @gateway.authorize(@amount, @credit_card, @options.merge(:eci => 4))
     assert_success response
-    assert_equal '3014726;PAU', response.authorization
+    assert_equal '3014726;RES', response.authorization
     assert response.test?
   end
 
@@ -125,7 +125,7 @@ class BarclaysEpdqExtraPlusTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).returns(successful_3dsecure_purchase_response)
     assert response = @gateway.authorize(@amount, @credit_card, @options.merge(:d3d => true))
     assert_success response
-    assert_equal '3014726;PAU', response.authorization
+    assert_equal '3014726;RES', response.authorization
     assert response.params['HTML_ANSWER']
     assert_equal nil, response.params['HTML_ANSWER'] =~ /<HTML_ANSWER>/
     assert response.test?
@@ -187,7 +187,7 @@ class BarclaysEpdqExtraPlusTest < Test::Unit::TestCase
     @gateway.expects(:ssl_post).times(2).returns(successful_purchase_response)
     assert response = @gateway.store(@credit_card, :billing_id => @billing_id)
     assert_success response
-    assert_equal '3014726;PAU', response.authorization
+    assert_equal '3014726;RES', response.authorization
     assert_equal '2', response.billing_id
     assert response.test?
   end
@@ -199,7 +199,7 @@ class BarclaysEpdqExtraPlusTest < Test::Unit::TestCase
     assert_deprecation_warning(BarclaysEpdqExtraPlusGateway::OGONE_STORE_OPTION_DEPRECATION_MESSAGE) do
       assert response = @gateway.store(@credit_card, :store => @billing_id)
       assert_success response
-      assert_equal '3014726;PAU', response.authorization
+      assert_equal '3014726;RES', response.authorization
       assert response.test?
     end
   end


### PR DESCRIPTION
https://github.com/activemerchant/active_merchant/commit/50a5f33da0e9a9b3ae998ea0fcb2fbe956d86c27
Stripe API keys can be up to 255 characters now, and these longer
keys ended up with line breaks when encoded in the headers, causing
the error: `ArgumentError: header field value cannot include CR/LF`.
Use strict_encode64 to prevent these characters from being added.