### PR TITLE
Add minimum auth amount for PLN

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -65,7 +65,8 @@ module ActiveMerchant #:nodoc:
         "JPY" => 100,
         "MXN" => 2000,
         "SGD" => 100,
-        "HKD" => 800
+        "HKD" => 800,
+        "PLN" => 200
       }
 
       def initialize(options = {})


### PR DESCRIPTION
https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts

Stripe authorization is failing as it's trying to use default 100 subunit for PLN currency but Stripe added minimum value as 2.00PLN.